### PR TITLE
fix audit open logic

### DIFF
--- a/main.go
+++ b/main.go
@@ -46,6 +46,7 @@ func main() {
 	url := ginSwagger.URL("/swagger/doc.json") // The url pointing to API definition
 	router.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler, url))
 
+	router.GET(apiPathAuditRoot+"/enabled", audit.IsEnabled)
 	router.POST(apiPathAuditRoot+"/k8s", audit.HandleK8sAuditLog)
 	router.POST(apiPathAuditRoot+"/cube", audit.HandleCubeAuditLog)
 	router.GET(apiPathAuditRoot, audit.SearchAuditLog)

--- a/pkg/audit/search.go
+++ b/pkg/audit/search.go
@@ -202,9 +202,9 @@ func searchLog(query auditQuery) (EsResult, *errcode.ErrorInfo) {
 
 	var esResult EsResult
 	// connect to es
-	client, err := elastic.NewClient(elastic.SetSniff(false), elastic.SetURL(env.Webhook().Host))
+	client, err := elastic.NewClient(elastic.SetSniff(false), elastic.SetURL(env.ElasticSearchHost().Host))
 	if err != nil {
-		clog.Error("connect to elasticsearch error: %s, url: %s ", err, env.Webhook().Host)
+		clog.Error("connect to elasticsearch error: %s, url: %s ", err, env.ElasticSearchHost().Host)
 		return esResult, errcode.InternalServerError
 	}
 
@@ -250,7 +250,7 @@ func searchLog(query auditQuery) (EsResult, *errcode.ErrorInfo) {
 	}
 
 	res, err := client.Search().
-		Index(env.Webhook().Index).
+		Index(env.ElasticSearchHost().Index).
 		Query(boolQ).
 		From(query.Page*query.Size).
 		Size(query.Size).
@@ -301,4 +301,9 @@ func checkIsAdmin(userName string) bool {
 		}
 	}
 	return false
+}
+
+func IsEnabled(c *gin.Context) {
+	response.SuccessReturn(c, backend.SendElasticSearch)
+	return
 }

--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -58,7 +58,7 @@ type Backend struct {
 
 func NewBackend() *Backend {
 
-	esWebhook := env.Webhook()
+	esWebhook := env.ElasticSearchHost()
 	esUrl := esWebhook.Host + "/" + esWebhook.Index + "/" + esWebhook.Type
 	b := Backend{
 		url:                esUrl,

--- a/pkg/listener/listener.go
+++ b/pkg/listener/listener.go
@@ -18,6 +18,7 @@ package listener
 
 import (
 	"audit/pkg/backend"
+	"audit/pkg/utils/env"
 	"context"
 	"github.com/kubecube-io/kubecube/pkg/apis"
 	hotplugv1 "github.com/kubecube-io/kubecube/pkg/apis/hotplug/v1"
@@ -37,8 +38,9 @@ const (
 )
 
 var (
-	auditEnable         = false
-	elasticSearchEnable = false
+	auditEnable                 = false
+	internalElasticSearchEnable = false
+	elasticSearchEnable         = false
 )
 
 func Listener() {
@@ -83,16 +85,20 @@ func Listener() {
 				if component.Status == hotPlugComponentEnabled {
 					auditEnable = true
 				} else {
-					auditEnable = false
+					backend.SendElasticSearch = false
+					return
 				}
 			}
 			if component.Name == hotPlugComponentNameElasticsearch {
 				if component.Status == hotPlugComponentEnabled {
-					elasticSearchEnable = true
-				} else {
-					elasticSearchEnable = false
+					internalElasticSearchEnable = true
 				}
 			}
+		}
+		if env.Webhook() != nil {
+			elasticSearchEnable = true
+		} else if internalElasticSearchEnable == true {
+			elasticSearchEnable = true
 		}
 		if auditEnable && elasticSearchEnable {
 			backend.SendElasticSearch = true

--- a/pkg/utils/env/env.go
+++ b/pkg/utils/env/env.go
@@ -36,9 +36,17 @@ func Webhook() *EsWebhook {
 	index := os.Getenv("AUDIT_WEBHOOK_INDEX")
 	types := os.Getenv("AUDIT_WEBHOOK_TYPE")
 	if host == "" || index == "" || types == "" {
-		return &EsWebhook{defaultEsHost, defaultEsIndex, defaultEsType}
+		return nil
 	}
 	return &EsWebhook{host, index, types}
+}
+
+func ElasticSearchHost() *EsWebhook {
+	if Webhook() == nil {
+		return &EsWebhook{defaultEsHost, defaultEsIndex, defaultEsType}
+	} else {
+		return Webhook()
+	}
 }
 
 func JwtSecret() string {


### PR DESCRIPTION
修改开关逻辑为：
1. 如果hotplug中audit不为enabled，审计功能为关；
2. 如果kubecube-audit没有配置es地址的环境变量，查询hotplug中es是否为enabled，如果都没有，审计功能为关；
3. es地址优先使用用户配置的环境变量，如果环境变量中任一参数为空，使用内置的es。
